### PR TITLE
update deku dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4"
-deku = "0.13"
+deku = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warts"
-version = "0.3.3"
+version = "0.3.4"
 description = "Rust implementation of the warts format."
 license = "MIT"
 authors = ["Maxime Mouchet <maxime.mouchet@lip6.fr>"]

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -110,19 +110,20 @@ impl Debug for Flags {
 
 impl DekuRead<'_, Endian> for Flags {
     fn read(
-        input: &'_ BitSlice<Msb0, u8>,
+        input: &'_ BitSlice<u8, Msb0>,
         _ctx: Endian,
-    ) -> Result<(&'_ BitSlice<Msb0, u8>, Self), DekuError>
+    ) -> Result<(&'_ BitSlice<u8, Msb0>, Self), DekuError>
     where
         Self: Sized,
     {
-        let (read, flags) = Flags::from_slice(input.as_raw_slice());
+        let (_, body, _) = input.domain().region().unwrap();
+        let (read, flags) = Flags::from_slice(body);
         Ok((input.get((read * 8)..).unwrap(), flags))
     }
 }
 
 impl DekuWrite<Endian> for Flags {
-    fn write(&self, output: &mut BitVec<Msb0, u8>, ctx: Endian) -> Result<(), DekuError> {
+    fn write(&self, output: &mut BitVec<u8, Msb0>, ctx: Endian) -> Result<(), DekuError> {
         self.to_vec().write(output, ctx)
     }
 }
@@ -147,7 +148,7 @@ mod tests {
 
     #[test]
     fn single_byte_without_flags() {
-        let bitslice = bitvec![Msb0, u8; 0, 0, 0, 0, 0, 0, 0, 0];
+        let bitslice = bitvec![u8, Msb0; 0, 0, 0, 0, 0, 0, 0, 0];
         let (read, flags) = Flags::from_slice(bitslice.as_raw_slice());
         assert_eq!(read, 1);
         assert!(!flags.any());
@@ -155,7 +156,7 @@ mod tests {
 
     #[test]
     fn single_byte_with_flags() {
-        let bitslice = bitvec![Msb0, u8; 0, 1, 0, 0, 0, 0, 0, 1];
+        let bitslice = bitvec![u8, Msb0; 0, 1, 0, 0, 0, 0, 0, 1];
         let (read, flags) = Flags::from_slice(bitslice.as_raw_slice());
         assert_eq!(read, 1);
         assert!(flags.any());
@@ -166,7 +167,7 @@ mod tests {
 
     #[test]
     fn two_bytes_with_flags() {
-        let bitslice = bitvec![Msb0, u8; 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1];
+        let bitslice = bitvec![u8, Msb0; 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1];
         let (read, flags) = Flags::from_slice(bitslice.as_raw_slice());
         assert_eq!(read, 2);
         assert!(flags.any());

--- a/src/timeval.rs
+++ b/src/timeval.rs
@@ -21,7 +21,7 @@ pub struct Timeval {
 
 impl From<Timeval> for NaiveDateTime {
     fn from(x: Timeval) -> Self {
-        NaiveDateTime::from_timestamp(x.seconds as i64, x.microseconds * 1000)
+        NaiveDateTime::from_timestamp_opt(x.seconds as i64, x.microseconds * 1000).unwrap()
     }
 }
 
@@ -47,7 +47,10 @@ mod tests {
 
     #[test]
     fn from_date_time() {
-        let dt = NaiveDate::from_ymd(2021, 2, 9).and_hms(0, 11, 45);
+        let dt = NaiveDate::from_ymd_opt(2021, 2, 9)
+            .unwrap()
+            .and_hms_opt(0, 11, 45)
+            .unwrap();
         assert_eq!(NaiveDateTime::from(Timeval::from(dt)), dt);
     }
 }


### PR DESCRIPTION
Dependency [deku](https://github.com/sharksforarms/deku) 0.15 introduced major breaking change by upgrading to bitvec 1.0 (see [changelog](https://github.com/sharksforarms/deku/blob/master/CHANGELOG.md)). 

Had to modify the codebase a little to make it work.
Tests passes now but I lack of expertise on bitvec. May introduce untested breaking. 